### PR TITLE
fix: ajusta edição de clientes sem cep

### DIFF
--- a/src/pages/app/cadastro/clientes/novo.tsx
+++ b/src/pages/app/cadastro/clientes/novo.tsx
@@ -471,7 +471,7 @@ const NewPeople: NextPage<Props> = (props) => {
                 label="CEP"
                 value={cep}
                 setValue={maskCep}
-                endItem={cep.length === 9 ? getEndItemCep() : null}
+                endItem={cep?.length === 9 ? getEndItemCep() : null}
               />
             </Grid>
             <Grid item xs={4} sm={6} md={9} />
@@ -618,7 +618,7 @@ const NewPeople: NextPage<Props> = (props) => {
               label="CPF / CNPJ"
               value={cpfCnpj}
               setValue={maskCpfCnpj}
-              endItem={cpfCnpj.length === 18 ? getEndItemCnpj() : null}
+              endItem={cpfCnpj?.length === 18 ? getEndItemCnpj() : null}
             />
           </Grid>
           <Hidden xsDown>


### PR DESCRIPTION
Ao acessar a aba "Endereço" na edição de clientes, ocorria um erro caso esse cliente não tivesse um CEP.